### PR TITLE
Add support for arbitrary registry URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ Visit the npmjs.com profile of your dependencies by simply `CMD/Ctrl+click` on t
 ![link example](images/promo.gif)
 
 ## Custom Registry URL
+To change the URL, you can set the configuration value in `settings.json` as below:
+
+`"npmDependencyLinks.registryUrlPattern": "http://myCustomRegistry/{{pkg}}/package?queryparams"`
+
+Default value is `https://www.npmjs.com/package/{{pkg}}`
+
+Note that `{{pkg}}` is the only part of the pattern that will be set by this extension. E.g., If your pattern is `http://registry.mysite.com/package?name={{pkg}}?version=latest`. If you click on `npm-dependency-links`, then the resulting URL will be `http://registry.mysite.com/package?name=npm-dependency-links?version=latest`
+
+## Custom Registry URL (Legacy)
 You can also pass custom registry url. For example, if you are using verdaccio. Default value is `https://www.npmjs.com/package/`.
 
 To change the url, you need to set this configuration value in `settings.json`


### PR DESCRIPTION
Implements request #8 . But instead of overriding the behavior of the existing `registryUrl`, I added a new option `registryUrlPattern`.

See readme for usage and details.